### PR TITLE
Fixed a bug in the find command.

### DIFF
--- a/src/main/java/org/maxgamer/quickshop/command/subcommand/SubCommand_Find.java
+++ b/src/main/java/org/maxgamer/quickshop/command/subcommand/SubCommand_Find.java
@@ -134,8 +134,8 @@ public class SubCommand_Find implements CommandHandler<Player> {
                         String.valueOf(location.getBlockZ()),
                         String.valueOf(shopDoubleEntry.getValue().intValue())
                 ).forLocale()).append("\n");
-                MsgUtil.sendDirectMessage(sender, stringBuilder.toString());
             }
+            MsgUtil.sendDirectMessage(sender, stringBuilder.toString());
         }
     }
 }


### PR DESCRIPTION
Fixed a problem where the find command would send a message as many times as the number of store chests.

The version used for verification is v5.0.0.16.

I think this bug is from 
[a218ffade7fc2b2a44eb177738c54d925b2fe8e0](https://github.com/PotatoCraft-Studio/QuickShop-Reremake/commit/a218ffade7fc2b2a44eb177738c54d925b2fe8e0#diff-0ac5c84a7a0c98f0d43e92c0476f0bdcff168ba48f46ec32fa5a507759a44f7f).

I have confirmed that we were able to fix the problem in the local environment.

before
![fix before](https://user-images.githubusercontent.com/76208219/143674260-6d2d4529-5785-4ce1-8257-b550226575e7.png)

after
![fix after](https://user-images.githubusercontent.com/76208219/143674263-0699b3c8-7062-42b7-a08b-10793e7c9694.png)


