### PR TITLE
Fix price command bypassing the integer only option.

### DIFF
--- a/src/main/java/org/maxgamer/quickshop/command/subcommand/SubCommand_Price.java
+++ b/src/main/java/org/maxgamer/quickshop/command/subcommand/SubCommand_Price.java
@@ -122,6 +122,11 @@ public class SubCommand_Price implements CommandHandler<Player> {
                 return;
             }
 
+            if (checkResult.getStatus() == PriceLimiterStatus.NOT_A_WHOLE_NUMBER) {
+                plugin.text().of(sender, "not-a-integer", price).send();
+                return;
+            }
+
             if (fee > 0) {
                 EconomyTransaction transaction = EconomyTransaction.builder()
                         .allowLoan(plugin.getConfiguration().getOrDefault("shop.allow-economy-loan", false))


### PR DESCRIPTION
Fixes the not a whole number status not being checked for when using /qs price.