### PR TITLE
Fix Issue #42 - Be mindful of non-symmetric matching functions

### DIFF
--- a/src/main/java/org/maxgamer/quickshop/shop/ContainerShop.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/ContainerShop.java
@@ -321,7 +321,7 @@ public class ContainerShop implements Shop {
                 if (stack == null || stack.getType() == Material.AIR) {
                     continue; // No item
                 }
-                if (matches(stack)) {
+                if (matches(stack, true)) {
                     int stackSize = Math.min(amount, stack.getAmount());
                     stack.setAmount(stack.getAmount() - stackSize);
                     amount -= stackSize;
@@ -346,7 +346,7 @@ public class ContainerShop implements Shop {
             Inventory chestInv = this.getInventory();
             for (int i = 0; amount > 0 && i < contents.length; i++) {
                 ItemStack item = contents[i];
-                if (item != null && this.matches(item)) {
+                if (item != null && this.matches(item, true)) {
                     // Copy it, we don't want to interfere
                     item = item.clone();
                     // Amount = total, item.getAmount() = how many items in the
@@ -510,6 +510,17 @@ public class ContainerShop implements Shop {
      */
     @Override
     public boolean matches(@Nullable ItemStack item) {
+        return this.matches(item, false);
+    }
+
+    /**
+     * Returns true if the ItemStack matches what this shop is selling/buying
+     *
+     * @param item The ItemStack
+     * @param buying Some matching functions are not symmetric, this decides the order it will check
+     * @return True if the ItemStack is the same (Excludes amounts)
+     */
+    public boolean matches(@Nullable ItemStack item, boolean buying) {
         if (item == null) {
             return false;
         }
@@ -517,7 +528,8 @@ public class ContainerShop implements Shop {
         guest.setAmount(1);
         ItemStack owner = this.item.clone();
         owner.setAmount(1);
-        return plugin.getItemMatcher().matches(guest, owner);
+        return buying ? plugin.getItemMatcher().matches(guest, owner) : 
+            plugin.getItemMatcher().matches(owner, guest);
     }
 
     @Override
@@ -646,7 +658,7 @@ public class ContainerShop implements Shop {
             for (int i = 0; amount > 0 && i < chestContents.length; i++) {
                 // Can't clone it here, it could be null
                 ItemStack item = chestContents[i];
-                if (item != null && item.getType() != Material.AIR && this.matches(item)) {
+                if (item != null && item.getType() != Material.AIR && this.matches(item, false)) {
                     // Copy it, we don't want to interfere
                     item = item.clone();
                     // Amount = total, item.getAmount() = how many items in the


### PR DESCRIPTION
This fixes issue #42 

This caused by the matching functions having the parameter ordering different between counting and the purchase action.

Because the matching function is not symmetric, it needs to be flipped for buying vs selling; in addition, it needs to be identical to the count function.