### PR TITLE
Fix Issue #100 - The same text may appear in multiple chats.

### DIFF
--- a/src/main/java/org/maxgamer/quickshop/listener/AbstractQSListener.java
+++ b/src/main/java/org/maxgamer/quickshop/listener/AbstractQSListener.java
@@ -26,6 +26,7 @@ import org.maxgamer.quickshop.util.reload.Reloadable;
 
 public abstract class AbstractQSListener implements Listener, Reloadable {
     protected final QuickShop plugin;
+    private boolean isRegistered = false;
 
     public AbstractQSListener(QuickShop plugin) {
         this.plugin = plugin;
@@ -33,10 +34,13 @@ public abstract class AbstractQSListener implements Listener, Reloadable {
     }
 
     public void register() {
+        if (isRegistered) return;
+        isRegistered = true;
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
     }
 
     public void unregister() {
         HandlerList.unregisterAll(this);
     }
+
 }

--- a/src/main/java/org/maxgamer/quickshop/localization/text/distributions/crowdin/CrowdinOTA.java
+++ b/src/main/java/org/maxgamer/quickshop/localization/text/distributions/crowdin/CrowdinOTA.java
@@ -88,8 +88,8 @@ public class CrowdinOTA implements Distribution {
      */
     public Map<String, String> genLanguageMapping() {
         Map<String, String> mapping = new HashMap<>();
-        JsonElement element = JsonParser.parseString(getManifestJson());
-        for (Map.Entry<String, JsonElement> set : element.getAsJsonObject().getAsJsonObject("language_mapping").entrySet()) {
+        JsonElement parser = new JsonParser().parse(getManifestJson());
+        for (Map.Entry<String, JsonElement> set : parser.getAsJsonObject().getAsJsonObject("language_mapping").entrySet()) {
             if (!set.getValue().isJsonObject()) {
                 continue;
             }


### PR DESCRIPTION
This fix #100 .
It's caused because listeners extended `AbstractQSListener` were registered twice.

The method `JsonParser.parseString` doesn't work in 1.15.2 or eariler, maybe `new JsonParser().parse` is still a better way.
