### PR TITLE
Removed all the jar signage bullshit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,30 +293,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jarsigner-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <phase>${mvn.sign.phrase}</phase>
-                        <id>sign</id>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <archive>${project.basedir}/target/${artifactId}.jar</archive>
-                    <keystore>${project.basedir}/keystore.jks</keystore>
-                    <alias>selfsigned</alias>
-                    <!--suppress UnresolvedMavenProperty -->
-                    <storepass>${env.quickshop-signer-pwd}</storepass>
-                    <!--suppress UnresolvedMavenProperty -->
-                    <keypass>${env.quickshop-signer-pwd}</keypass>
-                </configuration>
-            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/src/main/java/org/maxgamer/quickshop/QuickShop.java
+++ b/src/main/java/org/maxgamer/quickshop/QuickShop.java
@@ -785,68 +785,11 @@ public class QuickShop extends JavaPlugin implements QuickShopAPI {
         // Check If we need kill the server or disable plugin
 
         switch (resultReport.getFinalResult()) {
-            case DISABLE_PLUGIN:
-                Bukkit.getPluginManager().disablePlugin(this);
-                break;
-            case STOP_WORKING:
-                setupBootError(new BootError(this.getLogger(), joiner.toString()), true);
-                PluginCommand command = getCommand("qs");
-                if (command != null) {
-                    Util.mainThreadRun(() -> command.setTabCompleter(this)); //Disable tab completer
-                }
-                break;
-            case KILL_SERVER:
-                getLogger().severe("[Security Risk Detected] QuickShop forcing crash the server for security, contact the developer for details.");
-                String result = environmentChecker.getReportMaker().bake();
-                File reportFile = writeSecurityReportToFile();
-                URI uri = null;
-                if (reportFile != null) {
-                    uri = reportFile.toURI();
-                }
-                if (uri != null) {
-                    getLogger().warning("[Security Risk Detected] To get more details, please check: " + uri);
-                    try {
-                        if (java.awt.Desktop.isDesktopSupported()) {
-                            java.awt.Desktop dp = java.awt.Desktop.getDesktop();
-                            if (dp.isSupported(java.awt.Desktop.Action.BROWSE)) {
-                                dp.browse(uri);
-                                getLogger().warning("[Security Risk Detected] A browser already open for you. ");
-                            }
-                        }
-                    } catch (Throwable ignored) {
-                        //If failed, write directly to console
-                        getLogger().severe(result);
-                    }
-                } else {
-                    //If write failed, write directly to console
-                    getLogger().severe(result);
-                }
-                //Wait for a while for user and logger outputting
-                try {
-                    //10 seconds
-                    Thread.yield();
-                    Thread.sleep(10000);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-                // Halt the process, kill the server
-                Runtime.getRuntime().halt(-1);
+
             default:
                 break;
         }
         testing = false;
-    }
-
-    private File writeSecurityReportToFile() {
-        File file = new File(getDataFolder(), UUID.randomUUID() + ".security.letter.txt");
-        try {
-            Files.write(new File(getDataFolder(), UUID.randomUUID() + ".security.letter.txt").toPath(), environmentChecker.getReportMaker().bake().getBytes(StandardCharsets.UTF_8));
-            file = file.getCanonicalFile();
-        } catch (IOException e) {
-            getLogger().log(Level.SEVERE, "Failed to write security report!", e);
-            return null;
-        }
-        return file;
     }
 
     @Override

--- a/src/main/java/org/maxgamer/quickshop/util/envcheck/EnvironmentChecker.java
+++ b/src/main/java/org/maxgamer/quickshop/util/envcheck/EnvironmentChecker.java
@@ -44,8 +44,8 @@ import java.util.zip.ZipFile;
 public final class EnvironmentChecker {
     private final QuickShop plugin;
     private final List<Method> tests = new ArrayList<>();
-    @Getter
-    private final SecurityReport reportMaker = new SecurityReport();
+    //@Getter
+    //private final SecurityReport reportMaker = new SecurityReport();
 
     public EnvironmentChecker(QuickShop plugin) {
         this.plugin = plugin;
@@ -193,13 +193,13 @@ public final class EnvironmentChecker {
                  InputStream stream3 = loader.getResourceAsStream("META-INF/SELFSIGN.SF")) {
                 if (stream1 == null || stream2 == null || stream3 == null) {
                     if(stream1 == null){
-                        this.reportMaker.signatureFileMissing("META-INF/MANIFEST.MF");
+                        //this.reportMaker.signatureFileMissing("META-INF/MANIFEST.MF");
                     }
                     if(stream2 == null){
-                        this.reportMaker.signatureFileMissing("META-INF/SELFSIGN.DSA");
+                        //this.reportMaker.signatureFileMissing("META-INF/SELFSIGN.DSA");
                     }
                     if(stream3 == null){
-                        this.reportMaker.signatureFileMissing("META-INF/SELFSIGN.SF");
+                        //this.reportMaker.signatureFileMissing("META-INF/SELFSIGN.SF");
                     }
                     plugin.getLogger().warning("The signature could not be found! The QuickShop jar has been modified or you're running a custom build.");
                     return new ResultContainer(CheckResult.KILL_SERVER, "Security risk detected, QuickShop jar has been modified.");
@@ -214,7 +214,7 @@ public final class EnvironmentChecker {
                 return new ResultContainer(CheckResult.PASSED, "The jar is valid. No issues detected.");
             } else {
                 modifiedEntry.forEach(jarEntry -> {
-                    this.reportMaker.signatureVerifyFail(jarEntry);
+                    //this.reportMaker.signatureVerifyFail(jarEntry);
                     plugin.getLogger().warning(">> Modified Class Detected <<");
                     plugin.getLogger().warning("Name: " + jarEntry.getName());
                     plugin.getLogger().warning("CRC: " + jarEntry.getCrc());
@@ -243,7 +243,7 @@ public final class EnvironmentChecker {
     public ResultContainer manifestCheck() {
         String mainClass = plugin.getDescription().getMain();
         if(!mainClass.equals("org.maxgamer.quickshop.QuickShop")){
-            this.reportMaker.manifestModified(plugin.getDescription());
+            //this.reportMaker.manifestModified(plugin.getDescription());
             plugin.getLogger().warning("ALERT: Detected main class has been modified!");
             plugin.getLogger().warning("Should be: org.maxgamer.quickshop.QuickShop");
             plugin.getLogger().warning("Actually: "+mainClass);
@@ -266,7 +266,7 @@ public final class EnvironmentChecker {
                 ZipEntry entry = zipEntryEnumeration.nextElement();
                 if(entry.getName().startsWith("javassist") || entry.getName().startsWith(".")){
                     found = true;
-                    this.reportMaker.potentialInfected(entry);
+                    //this.reportMaker.potentialInfected(entry);
                     plugin.getLogger().log(Level.WARNING, "Potential Infection Detected:");
                     plugin.getLogger().log(Level.WARNING, "File: "+entry.getName());
                     plugin.getLogger().log(Level.WARNING, "CRC: "+entry.getCrc());


### PR DESCRIPTION
Hi everyone!

This PR removes the .jar signing, which cannot be done by people self-compiling this plugin, since they don't have the passphrase/key needed to sign it, and also prevents the plugin from "killing the server for security reasons" when the signature is not found.

Reason: It adds no meaningful security anway. People who want to share a malicious version can easily remove the code themselves.