### PR TITLE
SubCommand_Find: Add finding enchantments on enchanted books

### DIFF
--- a/src/main/java/org/maxgamer/quickshop/command/subcommand/SubCommand_Find.java
+++ b/src/main/java/org/maxgamer/quickshop/command/subcommand/SubCommand_Find.java
@@ -92,7 +92,7 @@ public class SubCommand_Find implements CommandHandler<Player> {
                 // Collect valid shop that trading items we want
                 if (!Util.getItemStackName(shop.getItem()).toLowerCase().contains(lookFor)
                         && !shop.getItem().getType().name().toLowerCase().contains(lookFor)
-                        && !Util.listContainsString(Util.getBooksEnchantments(shop.getItem()), lookFor)) {
+                        && !Util.isBookEnchantmentsMatched(shop.getItem(), lookFor)) {
                     continue;
                 }
                 if (excludeOutOfStock) {

--- a/src/main/java/org/maxgamer/quickshop/command/subcommand/SubCommand_Find.java
+++ b/src/main/java/org/maxgamer/quickshop/command/subcommand/SubCommand_Find.java
@@ -89,13 +89,11 @@ public class SubCommand_Find implements CommandHandler<Player> {
             double distance = shopVector.distance(playerVector);
             //Check distance
             if (distance <= maxDistance) {
-                //Collect valid shop that trading items we want
-                if (!Util.getItemStackName(shop.getItem()).toLowerCase().contains(lookFor)) {
-                    if (!shop.getItem().getType().name().toLowerCase().contains(lookFor)) {
-                        if (!Util.listContainsString(Util.getBooksEnchantments(shop.getItem()), lookFor)) {
-                            continue;
-                        }
-                    }
+                // Collect valid shop that trading items we want
+                if (!Util.getItemStackName(shop.getItem()).toLowerCase().contains(lookFor)
+                        && !shop.getItem().getType().name().toLowerCase().contains(lookFor)
+                        && !Util.listContainsString(Util.getBooksEnchantments(shop.getItem()), lookFor)) {
+                    continue;
                 }
                 if (excludeOutOfStock) {
                     if ((shop.isSelling() && shop.getRemainingStock() == 0) || (shop.isBuying() && shop.getRemainingSpace() == 0)) {

--- a/src/main/java/org/maxgamer/quickshop/command/subcommand/SubCommand_Find.java
+++ b/src/main/java/org/maxgamer/quickshop/command/subcommand/SubCommand_Find.java
@@ -92,7 +92,9 @@ public class SubCommand_Find implements CommandHandler<Player> {
                 //Collect valid shop that trading items we want
                 if (!Util.getItemStackName(shop.getItem()).toLowerCase().contains(lookFor)) {
                     if (!shop.getItem().getType().name().toLowerCase().contains(lookFor)) {
-                        continue;
+                        if (!Util.listContainsString(Util.getBooksEnchantments(shop.getItem()), lookFor)) {
+                            continue;
+                        }
                     }
                 }
                 if (excludeOutOfStock) {

--- a/src/main/java/org/maxgamer/quickshop/util/Util.java
+++ b/src/main/java/org/maxgamer/quickshop/util/Util.java
@@ -577,36 +577,33 @@ public class Util {
     }
 
     /**
-     * Get a String List of all enchants on an enchanted book
+     * Check all enchantments on a book and return true if they contain the
+     * nameToMatch
      * 
-     * @param itemStack
+     * @param itemStack The enchanted book itemstack
+     * @param String    The name of the enchant to check the book for
      * @return The names of enchants contained on the enchanted book
      */
     @NotNull
-    public static List<String> getBooksEnchantments(@NotNull ItemStack itemStack) {
-        List<String> enchants = new ArrayList<>();
+    public static boolean isBookEnchantmentsMatched(@NotNull ItemStack itemStack, @NotNull String nameToMatch) {
         if (itemStack.getType() == Material.ENCHANTED_BOOK) {
-            EnchantmentStorageMeta meta = (EnchantmentStorageMeta) itemStack.getItemMeta();
-            if (meta.hasStoredEnchants()) {
-                for (Enchantment enchant : meta.getStoredEnchants().keySet()) {
-                    enchants.add(enchant.getKey().getKey());
+            ItemMeta itemMeta = itemStack.getItemMeta();
+            if (!(itemMeta instanceof EnchantmentStorageMeta))
+                return false;
+            EnchantmentStorageMeta enchantmentStorageMeta = (EnchantmentStorageMeta) itemStack.getItemMeta();
+            if (enchantmentStorageMeta.hasStoredEnchants()) {
+                for (Enchantment enchantment : enchantmentStorageMeta.getStoredEnchants().keySet()) {
+                    nameToMatch = nameToMatch.toUpperCase(Locale.ROOT);
+                    if (enchantment.getKey().getKey().toUpperCase(Locale.ROOT).contains(nameToMatch)
+                            || MsgUtil.getEnchi18n(enchantment).toUpperCase(Locale.ROOT).contains(nameToMatch)) {
+                        return true;
+                    }
                 }
             }
         }
-        return enchants;
+        return false;
     }
 
-    @NotNull
-    public static boolean listContainsString(@NotNull List<String> list, @NotNull String string) {
-        boolean stringFound = false;
-        if (!list.isEmpty()) {
-            for (String entry : list) {
-                if (entry.contains(string))
-                    stringFound = true;
-            }
-        }
-        return stringFound;
-    }
     @NotNull
     public static String getFirstEnchantmentName(@NotNull EnchantmentStorageMeta meta) {
         if (!meta.hasStoredEnchants()) {

--- a/src/main/java/org/maxgamer/quickshop/util/Util.java
+++ b/src/main/java/org/maxgamer/quickshop/util/Util.java
@@ -599,7 +599,7 @@ public class Util {
     @NotNull
     public static boolean listContainsString(@NotNull List<String> list, @NotNull String string) {
         boolean stringFound = false;
-        if (list.size() > 0) {
+        if (!list.isEmpty()) {
             for (String entry : list) {
                 if (entry.contains(string))
                     stringFound = true;

--- a/src/main/java/org/maxgamer/quickshop/util/Util.java
+++ b/src/main/java/org/maxgamer/quickshop/util/Util.java
@@ -94,6 +94,7 @@ import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;

--- a/src/main/java/org/maxgamer/quickshop/util/Util.java
+++ b/src/main/java/org/maxgamer/quickshop/util/Util.java
@@ -576,6 +576,37 @@ public class Util {
         return result == null ? MsgUtil.getItemi18n(itemStack.getType().name()) : result;
     }
 
+    /**
+     * Get a String List of all enchants on an enchanted book
+     * 
+     * @param itemStack
+     * @return The names of enchants contained on the enchanted book
+     */
+    @NotNull
+    public static List<String> getBooksEnchantments(@NotNull ItemStack itemStack) {
+        List<String> enchants = new ArrayList<>();
+        if (itemStack.getType() == Material.ENCHANTED_BOOK) {
+            EnchantmentStorageMeta meta = (EnchantmentStorageMeta) itemStack.getItemMeta();
+            if (meta.hasStoredEnchants()) {
+                for (Enchantment enchant : meta.getStoredEnchants().keySet()) {
+                    enchants.add(enchant.getKey().getKey());
+                }
+            }
+        }
+        return enchants;
+    }
+
+    @NotNull
+    public static boolean listContainsString(@NotNull List<String> list, @NotNull String string) {
+        boolean stringFound = false;
+        if (list.size() > 0) {
+            for (String entry : list) {
+                if (entry.contains(string))
+                    stringFound = true;
+            }
+        }
+        return stringFound;
+    }
     @NotNull
     public static String getFirstEnchantmentName(@NotNull EnchantmentStorageMeta meta) {
         if (!meta.hasStoredEnchants()) {


### PR DESCRIPTION
This feature allows `/qs find` to search enchantments on enchanted books.

Being able to just search for enchanted books is usually not enough especially on servers with large shopping districts where you can spend ages browsing around to find the one specific enchant you want out of dozens and dozens of books.