### PR TITLE
Allow shop creation in creative mode with items in hand

### DIFF
--- a/src/main/java/org/maxgamer/quickshop/listener/PlayerListener.java
+++ b/src/main/java/org/maxgamer/quickshop/listener/PlayerListener.java
@@ -278,8 +278,7 @@ public class PlayerListener extends AbstractQSListener {
                 && shop == null
                 && item != null
                 && item.getType() != Material.AIR
-                && QuickShop.getPermissionManager().hasPermission(p, "quickshop.create.sell")
-                && p.getGameMode() != GameMode.CREATIVE) {
+                && QuickShop.getPermissionManager().hasPermission(p, "quickshop.create.sell")) {
             if (e.useInteractedBlock() == Event.Result.DENY
                     || !InteractUtil.check(InteractUtil.Action.CREATE, p.isSneaking())
                     || plugin.getConfig().getBoolean("shop.disable-quick-create")
@@ -321,6 +320,10 @@ public class PlayerListener extends AbstractQSListener {
                     break;
                 }
                 last = n;
+            }
+            if (p.getGameMode() == GameMode.CREATIVE) {
+                // If in creative mode, cancel the block breaking, to allow the shop creation
+                e.setCancelled(true);
             }
             // Send creation menu.
             final SimpleInfo info = new SimpleInfo(b.getLocation(), ShopAction.CREATE, e.getItem(), last, false);


### PR DESCRIPTION
![2023-12-28_04h39_30](https://github.com/PotatoCraft-Studio/QuickShop-Reremake/assets/16362824/8f0e3f09-5502-4645-8688-14d42d4d0ee4)

I would like to request a feature that would make it easier to create admin shops in creative mode. Currently, I have to switch back to survival mode every time I want to create a shop, which is very inconvenient.

My proposed feature is that when I left-click a chest with an item in hand in creative mode, it would allow me to create a shop with that item. The block breaking event would be cancelled, so the chest would not be destroyed.

This feature would be very useful for server owners and admins who want to set up shops quickly and easily in creative mode. I hope you will consider adding this feature to your plugin. Thank you for your hard work and dedication.