### PR TITLE
Allow the shop creation in creative mode

### DIFF
--- a/src/main/java/org/maxgamer/quickshop/listener/PlayerListener.java
+++ b/src/main/java/org/maxgamer/quickshop/listener/PlayerListener.java
@@ -278,8 +278,7 @@ public class PlayerListener extends AbstractQSListener {
                 && shop == null
                 && item != null
                 && item.getType() != Material.AIR
-                && QuickShop.getPermissionManager().hasPermission(p, "quickshop.create.sell")
-                && p.getGameMode() != GameMode.CREATIVE) {
+                && QuickShop.getPermissionManager().hasPermission(p, "quickshop.create.sell")) {
             if (e.useInteractedBlock() == Event.Result.DENY
                     || !InteractUtil.check(InteractUtil.Action.CREATE, p.isSneaking())
                     || plugin.getConfig().getBoolean("shop.disable-quick-create")
@@ -321,6 +320,10 @@ public class PlayerListener extends AbstractQSListener {
                     break;
                 }
                 last = n;
+            }
+            if (p.getGameMode() == GameMode.CREATIVE) {
+                // If in creative mode, cancel the block breaking, to allow the shop creation
+                e.setCancelled(true);
             }
             // Send creation menu.
             final SimpleInfo info = new SimpleInfo(b.getLocation(), ShopAction.CREATE, e.getItem(), last, false);


### PR DESCRIPTION
In this PR, you can also create a store in creative mode by “left clicking while holding an item against a chest”.

You can destroy the chest normally by left-clicking on it with your bare hands.

## Background
In creative mode, you cannot create a chest-shop by left-clicking on a chest, so you have to switch game modes every time you create an admin store, which is tedious.
